### PR TITLE
Update Faucetium

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -427,8 +427,8 @@ if test x$use_hardening != xno; then
 
   if test x$TARGET_OS != xwindows; then
     # All windows code is PIC, forcing it on just adds useless compile warnings
-    AX_CHECK_COMPILE_FLAG([-fPIE],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fPIE"])
-    AX_CHECK_LINK_FLAG([[-pie]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"])
+    AX_CHECK_COMPILE_FLAG([-fPIC],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fPIC"])
+    AX_CHECK_LINK_FLAG([[-fno-pie]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -fno-pie"])
   fi
 
   case $host in

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -1,0 +1,161 @@
+.NOTPARALLEL :
+
+SOURCES_PATH ?= $(BASEDIR)/sources
+BASE_CACHE ?= $(BASEDIR)/built
+SDK_PATH ?= $(BASEDIR)/SDKs
+NO_QT ?=
+NO_WALLET ?=
+NO_UPNP ?=
+FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
+
+BUILD = $(shell ./config.guess)
+HOST ?= $(BUILD)
+PATCHES_PATH = $(BASEDIR)/patches
+BASEDIR = $(CURDIR)
+HASH_LENGTH:=11
+DOWNLOAD_CONNECT_TIMEOUT:=10
+DOWNLOAD_RETRIES:=3
+
+host:=$(BUILD)
+ifneq ($(HOST),)
+host:=$(HOST)
+host_toolchain:=$(HOST)-
+endif
+
+ifneq ($(DEBUG),)
+release_type=debug
+else
+release_type=release
+endif
+
+base_build_dir=$(BASEDIR)/work/build
+base_staging_dir=$(BASEDIR)/work/staging
+base_download_dir=$(BASEDIR)/work/download
+canonical_host:=$(shell ./config.sub $(HOST))
+build:=$(shell ./config.sub $(BUILD))
+
+build_arch =$(firstword $(subst -, ,$(build)))
+build_vendor=$(word 2,$(subst -, ,$(build)))
+full_build_os:=$(subst $(build_arch)-$(build_vendor)-,,$(build))
+build_os:=$(findstring linux,$(full_build_os))
+build_os+=$(findstring darwin,$(full_build_os))
+build_os:=$(strip $(build_os))
+ifeq ($(build_os),)
+build_os=$(full_build_os)
+endif
+
+host_arch=$(firstword $(subst -, ,$(canonical_host)))
+host_vendor=$(word 2,$(subst -, ,$(canonical_host)))
+full_host_os:=$(subst $(host_arch)-$(host_vendor)-,,$(canonical_host))
+host_os:=$(findstring linux,$(full_host_os))
+host_os+=$(findstring darwin,$(full_host_os))
+host_os+=$(findstring mingw32,$(full_host_os))
+host_os:=$(strip $(host_os))
+ifeq ($(host_os),)
+host_os=$(full_host_os)
+endif
+
+$(host_arch)_$(host_os)_prefix=$(BASEDIR)/$(host)
+$(host_arch)_$(host_os)_host=$(host)
+host_prefix=$($(host_arch)_$(host_os)_prefix)
+build_prefix=$(host_prefix)/native
+build_host=$(build)
+
+AT_$(V):=
+AT_:=@
+AT:=$(AT_$(V))
+
+all: install
+
+include hosts/$(host_os).mk
+include hosts/default.mk
+include builders/$(build_os).mk
+include builders/default.mk
+include packages/packages.mk
+
+qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages)
+qt_native_packages_$(NO_QT) = $(qt_native_packages)
+wallet_packages_$(NO_WALLET) = $(wallet_packages)
+upnp_packages_$(NO_UPNP) = $(upnp_packages)
+
+packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
+native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages) $(qt_native_packages_)
+all_packages = $(packages) $(native_packages)
+
+meta_depends = Makefile funcs.mk builders/default.mk hosts/default.mk hosts/$(host_os).mk builders/$(build_os).mk
+
+$(host_arch)_$(host_os)_native_toolchain?=$($(host_os)_native_toolchain)
+
+include funcs.mk
+
+toolchain_path=$($($(host_arch)_$(host_os)_native_toolchain)_prefixbin)
+final_build_id_long+=$(shell $(build_SHA256SUM) config.site.in)
+final_build_id+=$(shell echo -n $(final_build_id_long) | $(build_SHA256SUM) | cut -c-$(HASH_LENGTH))
+$(host_prefix)/.stamp_$(final_build_id): $(native_packages) $(packages)
+	$(AT)rm -rf $(@D)
+	$(AT)mkdir -p $(@D)
+	$(AT)echo copying packages: $^
+	$(AT)echo to: $(@D)
+	$(AT)cd $(@D); $(foreach package,$^, tar xf $($(package)_cached); )
+	$(AT)touch $@
+
+$(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_build_id)
+	$(AT)@mkdir -p $(@D)
+	$(AT)sed -e 's|@HOST@|$(host)|' \
+            -e 's|@CC@|$(toolchain_path)$(host_CC)|' \
+            -e 's|@CXX@|$(toolchain_path)$(host_CXX)|' \
+            -e 's|@AR@|$(toolchain_path)$(host_AR)|' \
+            -e 's|@RANLIB@|$(toolchain_path)$(host_RANLIB)|' \
+            -e 's|@NM@|$(toolchain_path)$(host_NM)|' \
+            -e 's|@STRIP@|$(toolchain_path)$(host_STRIP)|' \
+            -e 's|@build_os@|$(build_os)|' \
+            -e 's|@host_os@|$(host_os)|' \
+            -e 's|@CFLAGS@|$(strip $(host_CFLAGS) $(host_$(release_type)_CFLAGS))|' \
+            -e 's|@CXXFLAGS@|$(strip $(host_CXXFLAGS) $(host_$(release_type)_CXXFLAGS))|' \
+            -e 's|@CPPFLAGS@|$(strip $(host_CPPFLAGS) $(host_$(release_type)_CPPFLAGS))|' \
+            -e 's|@LDFLAGS@|$(strip $(host_LDFLAGS) $(host_$(release_type)_LDFLAGS))|' \
+            -e 's|@no_qt@|$(NO_QT)|' \
+            -e 's|@no_wallet@|$(NO_WALLET)|' \
+            -e 's|@no_upnp@|$(NO_UPNP)|' \
+            -e 's|@debug@|$(DEBUG)|' \
+            $< > $@
+	$(AT)touch $@
+
+
+define check_or_remove_cached
+  mkdir -p $(BASE_CACHE)/$(host)/$(package) && cd $(BASE_CACHE)/$(host)/$(package); \
+  $(build_SHA256SUM) -c $($(package)_cached_checksum) >/dev/null 2>/dev/null || \
+  ( rm -f $($(package)_cached_checksum); \
+    if test -f "$($(package)_cached)"; then echo "Checksum mismatch for $(package). Forcing rebuild.."; rm -f $($(package)_cached_checksum) $($(package)_cached); fi )
+endef
+
+define check_or_remove_sources
+  mkdir -p $($(package)_source_dir); cd $($(package)_source_dir); \
+  $(build_SHA256SUM) -c $($(package)_fetched) >/dev/null 2>/dev/null || \
+    ( if test -f $($(package)_all_sources); then echo "Checksum missing or mismatched for $(package) source. Forcing re-download."; fi; \
+      rm -f $($(package)_all_sources) $($(1)_fetched))
+endef
+
+check-packages:
+	@$(foreach package,$(all_packages),$(call check_or_remove_cached,$(package));)
+check-sources:
+	@$(foreach package,$(all_packages),$(call check_or_remove_sources,$(package));)
+
+$(host_prefix)/share/config.site: check-packages
+
+check-packages: check-sources
+
+install: check-packages $(host_prefix)/share/config.site
+
+
+download-one: check-sources $(all_sources)
+
+download-osx:
+	@$(MAKE) -s HOST=x86_64-apple-darwin11 download-one
+download-linux:
+	@$(MAKE) -s HOST=x86_64-unknown-linux-gnu download-one
+download-win:
+	@$(MAKE) -s HOST=x86_64-w64-mingw32 download-one
+download: download-osx download-linux download-win
+
+.PHONY: install cached download-one download-osx download-linux download-win download check-packages check-sources

--- a/depends/patches/qt/fix-xcb-include-order.patch
+++ b/depends/patches/qt/fix-xcb-include-order.patch
@@ -1,0 +1,45 @@
+--- old/qtbase/src/plugins/platforms/xcb/xcb_qpa_lib.pro 2015-03-17 02:06:42.705930685 +0000
++++ new/qtbase/src/plugins/platforms/xcb/xcb_qpa_lib.pro 2015-03-17 02:08:41.281926351 +0000
+@@ -94,8 +94,6 @@
+
+ DEFINES += $$QMAKE_DEFINES_XCB
+ LIBS += $$QMAKE_LIBS_XCB
+-QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_XCB
+-QMAKE_CFLAGS += $$QMAKE_CFLAGS_XCB
+
+ CONFIG += qpa/genericunixfontdatabase
+
+@@ -104,7 +102,8 @@
+ contains(QT_CONFIG, xcb-qt) {
+     DEFINES += XCB_USE_RENDER
+     XCB_DIR = ../../../3rdparty/xcb
+-    INCLUDEPATH += $$XCB_DIR/include $$XCB_DIR/sysinclude
++    QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
++    QMAKE_CXXFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
+     LIBS += -lxcb -L$$OUT_PWD/xcb-static -lxcb-static
+ } else {
+     LIBS += -lxcb -lxcb-image -lxcb-icccm -lxcb-sync -lxcb-xfixes -lxcb-shm -lxcb-randr -lxcb-shape -lxcb-keysyms
+--- old/qtbase/src/plugins/platforms/xcb/xcb-static/xcb-static.pro      2015-03-17 02:07:04.641929383 +0000
++++ new/qtbase/src/plugins/platforms/xcb/xcb-static/xcb-static.pro      2015-03-17 02:10:15.485922059 +0000
+@@ -8,7 +8,8 @@
+
+ XCB_DIR = ../../../../3rdparty/xcb
+
+-INCLUDEPATH += $$XCB_DIR/include $$XCB_DIR/include/xcb $$XCB_DIR/sysinclude
++QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/include/xcb -I$$XCB_DIR/sysinclude
++QMAKE_CXXFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/include/xcb -I$$XCB_DIR/sysinclude
+
+ QMAKE_CXXFLAGS += $$QMAKE_CFLAGS_XCB
+ QMAKE_CFLAGS += $$QMAKE_CFLAGS_XCB
+--- old/qtbase/src/plugins/platforms/xcb/xcb-plugin.pro	2015-07-24 16:02:59.530038830 -0400
++++ new/qtbase/src/plugins/platforms/xcb/xcb-plugin.pro	2015-07-24 16:01:22.106037459 -0400
+@@ -11,3 +11,9 @@
+     qxcbmain.cpp
+ OTHER_FILES += xcb.json README
+
++contains(QT_CONFIG, xcb-qt) {
++    DEFINES += XCB_USE_RENDER
++    XCB_DIR = ../../../3rdparty/xcb
++    QMAKE_CFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
++    QMAKE_CXXFLAGS += -I$$XCB_DIR/include -I$$XCB_DIR/sysinclude $$QMAKE_CFLAGS_XCB
++}

--- a/depends/patches/qt/mingw-uuidof.patch
+++ b/depends/patches/qt/mingw-uuidof.patch
@@ -1,0 +1,44 @@
+--- old/qtbase/src/plugins/platforms/windows/qwindowscontext.cpp	2015-06-20 17:40:20.956781548 -0400
++++ new/qtbase/src/plugins/platforms/windows/qwindowscontext.cpp	2015-06-20 17:29:32.052772416 -0400
+@@ -69,7 +69,7 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <windowsx.h>
+-#ifndef Q_OS_WINCE
++#if !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+ #  include <comdef.h>
+ #endif
+ 
+@@ -762,7 +762,7 @@
+                           HWND_MESSAGE, NULL, (HINSTANCE)GetModuleHandle(0), NULL);
+ }
+ 
+-#ifndef Q_OS_WINCE
++#if !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+ // Re-engineered from the inline function _com_error::ErrorMessage().
+ // We cannot use it directly since it uses swprintf_s(), which is not
+ // present in the MSVCRT.DLL found on Windows XP (QTBUG-35617).
+@@ -781,7 +781,7 @@
+          return QStringLiteral("IDispatch error #") + QString::number(wCode);
+      return QStringLiteral("Unknown error 0x0") + QString::number(comError.Error(), 16);
+ }
+-#endif // !Q_OS_WINCE
++#endif // !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+ 
+ /*!
+     \brief Common COM error strings.
+@@ -846,12 +846,12 @@
+     default:
+         break;
+     }
+-#ifndef Q_OS_WINCE
++#if !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+     _com_error error(hr);
+     result += QByteArrayLiteral(" (");
+     result += errorMessageFromComError(error);
+     result += ')';
+-#endif // !Q_OS_WINCE
++#endif // !defined(Q_OS_WINCE) && (!defined(USE___UUIDOF) || (defined(USE___UUIDOF) && USE___UUIDOF == 1))
+     return result;
+ }
+ 

--- a/depends/patches/qt/pidlist_absolute.patch
+++ b/depends/patches/qt/pidlist_absolute.patch
@@ -1,0 +1,37 @@
+diff -dur old/qtbase/src/plugins/platforms/windows/qwindowscontext.h new/qtbase/src/plugins/platforms/windows/qwindowscontext.h
+--- old/qtbase/src/plugins/platforms/windows/qwindowscontext.h	2015-06-29 22:04:40.000000000 +0200
++++ new/qtbase/src/plugins/platforms/windows/qwindowscontext.h	2015-11-01 12:55:59.751234846 +0100
+@@ -124,10 +124,18 @@
+     inline void init();
+ 
+     typedef HRESULT (WINAPI *SHCreateItemFromParsingName)(PCWSTR, IBindCtx *, const GUID&, void **);
++#if defined(Q_CC_MINGW) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3)
++    typedef HRESULT (WINAPI *SHGetKnownFolderIDList)(const GUID &, DWORD, HANDLE, ITEMIDLIST **);
++#else
+     typedef HRESULT (WINAPI *SHGetKnownFolderIDList)(const GUID &, DWORD, HANDLE, PIDLIST_ABSOLUTE *);
++#endif
+     typedef HRESULT (WINAPI *SHGetStockIconInfo)(int , int , _SHSTOCKICONINFO *);
+     typedef HRESULT (WINAPI *SHGetImageList)(int, REFIID , void **);
++#if defined(Q_CC_MINGW) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3)
++    typedef HRESULT (WINAPI *SHCreateItemFromIDList)(const ITEMIDLIST *, REFIID, void **);
++#else
+     typedef HRESULT (WINAPI *SHCreateItemFromIDList)(PCIDLIST_ABSOLUTE, REFIID, void **);
++#endif
+ 
+     SHCreateItemFromParsingName sHCreateItemFromParsingName;
+     SHGetKnownFolderIDList sHGetKnownFolderIDList;
+diff -dur old/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp new/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
+--- old/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp	2015-06-29 22:04:40.000000000 +0200
++++ new/qtbase/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp	2015-11-01 13:41:09.503149772 +0100
+@@ -1008,7 +1008,11 @@
+             qWarning() << __FUNCTION__ << ": Invalid CLSID: " << url.path();
+             return Q_NULLPTR;
+         }
++#if defined(Q_CC_MINGW) && (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 3)
++        ITEMIDLIST *idList;
++#else
+         PIDLIST_ABSOLUTE idList;
++#endif
+         HRESULT hr = QWindowsContext::shell32dll.sHGetKnownFolderIDList(uuid, 0, 0, &idList);
+         if (FAILED(hr)) {
+             qErrnoWarning("%s: SHGetKnownFolderIDList(%s)) failed", __FUNCTION__, qPrintable(url.toString()));


### PR DESCRIPTION
#error "You must build your code with position independent code if Qt was built with -reduce-relocations."

-fpic
Generate position-independent code (PIC) suitable for use in a shared library...

-fpie
These options are similar to -fpic and -fPIC, but generated position independent code can be only linked into executables....

By building with fPIE, the resulting binaries are "LSB shared objects" not LSB executables. When trying to run the program (double-click) with mouse it doesn't start. Therefore this change fixes this.

The following files are added:

Faucetium/depends/Makefile
Faucetium/depends/patches/qt/fix-xcb-include-order.patch
Faucetium/depends/patches/qt/mingw-uuidof.patch
Faucetium/depends/patches/qt/pidlist_absolute.patch